### PR TITLE
[WIP] NEW: Add morph target names.

### DIFF
--- a/src/ExportableMesh.cpp
+++ b/src/ExportableMesh.cpp
@@ -10,6 +10,7 @@
 #include "ExportableNode.h"
 #include "accessors.h"
 #include "DagHelper.h"
+#include "GLTFTargetNames.h"
 
 ExportableMesh::ExportableMesh(
     ExportableScene& scene,
@@ -65,7 +66,7 @@ ExportableMesh::ExportableMesh(
         const size_t vertexBufferCount = vertexBufferEntries.size();
         {
             size_t vertexBufferIndex = 0;
-            for (auto && pair : vertexBufferEntries)
+            for (auto&& pair : vertexBufferEntries)
             {
                 const auto& vertexSignature = pair.first;
                 const auto& vertexBuffer = pair.second;
@@ -121,7 +122,6 @@ ExportableMesh::ExportableMesh(
 
                 ++vertexBufferIndex;
             }
-
             for (auto&& shape : mayaMesh->allShapes())
             {
                 if (shape->shapeIndex.isBlendShapeIndex())
@@ -129,7 +129,17 @@ ExportableMesh::ExportableMesh(
                     m_weightPlugs.emplace_back(shape->weightPlug);
                     m_initialWeights.emplace_back(shape->initialWeight);
                     glMesh.weights.emplace_back(shape->initialWeight);
+                    MStringArray weightArrays;
+                    MString weight = shape->weightPlug.name();
+                    weight.split('.', weightArrays);
+
+                    m_morphTargetNames->addName(weightArrays.length() <= 1
+                        ? std::string("morph_") + std::to_string(m_morphTargetNames->size())
+                        : std::string(weightArrays[1].asChar()));
                 }
+            }
+            if (!mayaMesh->allShapes().empty()) {
+                glMesh.extras.insert({ "targetNames", static_cast<GLTF::Object*>(m_morphTargetNames.get()) });
             }
         }
 

--- a/src/ExportableMesh.h
+++ b/src/ExportableMesh.h
@@ -38,9 +38,10 @@ private:
 
 	std::vector<float> m_initialWeights;
 	std::vector<MPlug> m_weightPlugs;
-	std::vector<std::unique_ptr<ExportablePrimitive>> m_primitives;
+    std::vector<std::unique_ptr<ExportablePrimitive>> m_primitives;
 
-	std::vector<Float4x4> m_inverseBindMatrices;
-	std::unique_ptr<GLTF::Accessor> m_inverseBindMatricesAccessor;
+    std::vector<Float4x4> m_inverseBindMatrices;
+    std::unique_ptr<GLTF::Accessor> m_inverseBindMatricesAccessor;
+    std::unique_ptr<GLTF::MorphTargetNames> m_morphTargetNames = std::make_unique<GLTF::MorphTargetNames>();
 };
 

--- a/src/externals.h
+++ b/src/externals.h
@@ -34,6 +34,7 @@
 #	pragma  warning(disable:4267)
 #endif
 
+#include <GLTFTargetNames.h>
 #include <GLTFAsset.h>
 #include <GLTFScene.h>
 #include <GLTFBuffer.h>


### PR DESCRIPTION
This adds blend shape name support. It requires https://github.com/WonderMediaProductions/COLLADA2GLTF/pull/1.

I'm using a raw pointer, but I think that's wrong. Suggestions?

```cpp
GLTF::Object* morphTargetNames = new GLTF::MorphTargetNames;
```

Sponsored by IMVU Inc.