### PR TITLE
FIX: Crash when images are not found.

### DIFF
--- a/tools/ModelClipMerger/ModelClipMerger.cs
+++ b/tools/ModelClipMerger/ModelClipMerger.cs
@@ -96,9 +96,12 @@ namespace WonderMedia.glTF.ModelClipMerger
 
             Log.WriteLine($"Copying images...");
 
-            using (Log.Indented())
+            if (modelData.Images != null)
             {
-                CopyImages(modelData, modelPath, outputModelFolder);
+                using (Log.Indented())
+                {
+                    CopyImages(modelData, modelPath, outputModelFolder);
+                }
             }
 
             Log.WriteLine($"Fetching model buffers...");


### PR DESCRIPTION
It shouldn't crash when there's no images for a gltf file.

However, there should be a flag to ignore images in another pr.

Sponsored by imvu.