### PR TITLE
NEW: Disable optimization of empty weights via excludeZeroJoints

### DIFF
--- a/src/Arguments.cpp
+++ b/src/Arguments.cpp
@@ -82,6 +82,9 @@ const auto reportSkewedInverseBindMatrices = "rsb";
 const auto clearOutputWindow = "cow";
 
 const auto cameras = "cam";
+
+const auto excludeZeroJoints = "ezj";
+
 } // namespace flag
 
 inline const char *getArgTypeName(const MSyntax::MArgType argType) {
@@ -200,6 +203,8 @@ SyntaxFactory::SyntaxFactory() {
     registerFlag(ss, flag::clearOutputWindow, "clearOutputWindow", kNoArg);
 
     registerFlag(ss, flag::cameras, "cameras", kSelectionItem);
+
+    registerFlag(ss, flag::excludeZeroJoints, "excludeZeroJoints", kNoArg);
 
     m_usage = ss.str();
 }
@@ -578,6 +583,8 @@ Arguments::Arguments(const MArgList &args, const MSyntax &syntax) {
 
     adb.optional(flag::debugVectorLength, debugVectorLength);
     adb.optional(flag::copyright, copyright);
+
+    excludeZeroJoints = adb.isFlagSet(flag::excludeZeroJoints);
 
     adb.optional(flag::gltfFileExtension, gltfFileExtension);
     adb.optional(flag::glbFileExtension, glbFileExtension);

--- a/src/Arguments.h
+++ b/src/Arguments.h
@@ -249,6 +249,9 @@ class Arguments {
     /** Copyright text of the exported file */
     MString copyright;
 
+    /** Exclude zero joints from the mesh */
+    bool excludeZeroJoints = false;
+
     void assignName(GLTF::Object &glObj, const std::string &name) const {
         if (!disableNameAssignment) {
             glObj.name = name;

--- a/src/MeshSkeleton.cpp
+++ b/src/MeshSkeleton.cpp
@@ -123,7 +123,7 @@ MeshSkeleton::MeshSkeleton(ExportableScene &scene, const ExportableNode &node,
             for (int jointIndex = 0; jointIndex < int(numWeights);
                  ++jointIndex) {
                 const float jointWeight = vertexWeights[jointIndex];
-                if (std::abs(jointWeight) > 1e-6f) {
+                if (!args.excludeZeroJoints || std::abs(jointWeight) > 1e-6f) {
                     assignments.emplace_back(jointIndex, jointWeight);
                 }
             }


### PR DESCRIPTION
I don't have a test model so I was going to a boolean simplification, but I can't test the code.

```cpp
if (!args.excludeZeroJoints || std::abs(jointWeight) > 1e-6f) {
```

Do you have any test models that can use this code path?
