### PR TITLE
FIX: Add OSX Maya Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,12 +51,26 @@ ExternalProject_Add(GSL
 	-DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
 )
 
+# filesystem
+ExternalProject_Add(filesystem
+  GIT_REPOSITORY https://github.com/gulrak/filesystem
+  GIT_TAG v1.2.6
+  PREFIX filesystem
+  INSTALL_DIR
+  CMAKE_ARGS
+	-DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND ""
+  INSTALL_COMMAND ""
+)
+
 set(GLTF_INCLUDE_DIR          "${CMAKE_BINARY_DIR}/COLLADA2GLTF/src/COLLADA2GLTF/GLTF/include")
 set(DRACO_INCLUDE_DIR         "${CMAKE_BINARY_DIR}/COLLADA2GLTF/src/COLLADA2GLTF/GLTF/dependencies/draco/src")
 set(RAPIDJSON_INCLUDE_DIR     "${CMAKE_BINARY_DIR}/COLLADA2GLTF/src/COLLADA2GLTF/GLTF/dependencies/rapidjson/include")
 #set(COLLADA2GLTF_INCLUDE_DIR  "${CMAKE_BINARY_DIR}/COLLADA2GLTF/include")
 set(GSL_INCLUDE_DIR           "${CMAKE_BINARY_DIR}/GSL/include")
 set(LINQ_INCLUDE_DIR          "${CMAKE_BINARY_DIR}/linq/src/linq/lib")
+set(FS_INCLUDE_DIR            "${CMAKE_BINARY_DIR}/filesystem/src/filesystem/include")
 
 # TODO: It seems the gltf.lib is not installed by COLLADA2GLTF, although draco.lib is? Figure out why
 ExternalProject_Get_Property(COLLADA2GLTF binary_dir)
@@ -95,6 +109,7 @@ add_dependencies(${PROJECT_NAME}
   GSL
   COLLADA2GLTF
   linq
+  filesystem
 )
 
 target_link_libraries(${PROJECT_NAME} ${MAYA_LIBRARIES} GLTF draco)
@@ -106,6 +121,28 @@ if(MSVC)
     COMMAND xcopy /y "$<SHELL_PATH:${PROJECT_SOURCE_DIR}/maya/scripts/maya2glTF*.mel>" "$<SHELL_PATH:$ENV{USERPROFILE}/Documents/maya/${MAYA_VERSION}/scripts/>"
     COMMAND xcopy /y /s /i "$<SHELL_PATH:${PROJECT_SOURCE_DIR}/maya/renderData/*.*>" "$<SHELL_PATH:$ENV{USERPROFILE}/Documents/maya/maya2glTF/PBR/>"
     COMMAND if exist "$<SHELL_PATH:$<TARGET_PDB_FILE:maya2glTF>>" (xcopy /y /c "$<SHELL_PATH:$<TARGET_PDB_FILE:maya2glTF>>" "$<SHELL_PATH:$ENV{USERPROFILE}/Documents/maya/${MAYA_VERSION}/plug-ins/>")
+  )
+elseif(APPLE)
+  install (
+    TARGETS maya2glTF 
+    DESTINATION "/Users/Shared/Autodesk/maya/${MAYA_VERSION}/plug-ins/"
+  )
+  
+  install (
+    DIRECTORY "${PROJECT_SOURCE_DIR}/maya/scripts/" 
+    DESTINATION "/Users/Shared/Autodesk/maya/scripts"
+    FILES_MATCHING PATTERN "maya2glTF*.mel"
+  )
+
+  install (
+    DIRECTORY "${CMAKE_BINARY_DIR}/generated/" 
+    DESTINATION "/Users/Shared/Autodesk/maya/scripts"
+    FILES_MATCHING PATTERN "maya2glTF*.mel"
+  )
+
+  install (
+    DIRECTORY "${PROJECT_SOURCE_DIR}/maya/renderData/"
+    DESTINATION "/Users/Shared/Autodesk/maya/maya2glTF/PBR"
   )
 else(LINUX)
   add_custom_command(TARGET maya2glTF POST_BUILD

--- a/osx_create_project.sh
+++ b/osx_create_project.sh
@@ -1,0 +1,1 @@
+cmake -B "build" -G "Unix Makefiles" -D MAYA_VERSION:string=2019

--- a/src/ExportableAsset.cpp
+++ b/src/ExportableAsset.cpp
@@ -376,7 +376,7 @@ void ExportableAsset::save() {
 
         std::ofstream file;
         create(file, outputPath.string(),
-               ios::out | (args.glb ? ios::binary : std::_Ios_Openmode(0)));
+               ios::out | (args.glb ? ios::binary : std::ios_base::openmode(0)));             
 
         if (args.glb) {
             assert(packedBufferMap.size() <= 1);

--- a/src/ExportableResources.cpp
+++ b/src/ExportableResources.cpp
@@ -46,7 +46,7 @@ ExportableResources::getMaterial(const MObject &shaderGroup) {
 GLTF::Image *ExportableResources::getImage(fs::path path) {
     if (!exists(path)) {
         MayaException::printError(
-            formatted("Image with path '%s' does not exist!", path.generic_string().c_str()));
+            formatted("Image with path '%s' does not exist!", path.c_str()));
         MayaException::printError(
             "(it is advised to use a Maya project and relative paths)");
         return nullptr;
@@ -85,7 +85,7 @@ GLTF::Image *ExportableResources::getImage(fs::path path) {
             imagePtr.reset(GLTF::Image::load(path.generic_string()));
         } catch (std::exception &ex) {
             MayaException::printError(
-                formatted("Failed to load image '%s': %s", path, ex.what()));
+                formatted("Failed to load image '%s': %s", path.c_str(), ex.what()));
         }
     }
     return imagePtr.get();

--- a/src/ExportableTexture.cpp
+++ b/src/ExportableTexture.cpp
@@ -31,7 +31,7 @@ ExportableTexture::ExportableTexture(Private, ExportableResources &resources,
     if (!DagHelper::getPlugValue(connectedObject, "fileTextureName",
                                  imageFilePath)) {
         MayaException::printError(formatted("Failed to get %s.fileTextureName",
-                                            connectedNode.name()));
+                                            connectedNode.name().asChar()));
         return;
     }
 

--- a/src/SignalHandlers.h
+++ b/src/SignalHandlers.h
@@ -10,7 +10,9 @@ class SignalHandlers {
   private:
 #ifdef _WIN32
     _crt_signal_t m_previousAbortSignalHandler;
-#else 
+#elif __APPLE__
+    sig_t m_previousAbortSignalHandler;
+#else
     __sighandler_t m_previousAbortSignalHandler;
 #endif
     static void handleAbortSignal(int signalNumber);

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -1,5 +1,5 @@
 #pragma once
 
-#include <filesystem>
+#include "ghc/filesystem.hpp"
 
-namespace fs = std::filesystem;
+namespace fs = ghc::filesystem;


### PR DESCRIPTION
Work in progress.

```
 create(file, outputPath.string(),
               ios::out | (args.glb ? ios::binary : std::_Ios_Openmode(0)));
```

The zero needs to be in the proper class. Any ideas? `_Ios_Openmode` probably breaks on Linux and Windows.

This improves the glb and image fixes from develop to enable OSX support.